### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ BabyBluetooth *baby;
 
 # 如何安装
 
-##1 手动安装
+## 1 手动安装
 step1:将项目Classes/objc 文件夹中的文件直接拖入你的项目中即可
 
 step2:导入.h文件
@@ -163,7 +163,7 @@ step2:导入.h文件
 #import "BabyBluetooth.h"
 ````
 
-##2 cocoapods
+## 2 cocoapods
 step1:add the following line to your Podfile:
 ````
 pod 'BabyBluetooth','~> 0.7.0'

--- a/README_en.md
+++ b/README_en.md
@@ -3,7 +3,7 @@
 
 The easiest way to use Bluetooth (BLE )in ios,even baby can use .  CoreBluetooth wrap.
 
-#feature
+# feature
 
 - 1:CoreBluetooth wrap，simple and eary for use.
 - 2:CoreBluetooth is dependency on delegate ,and most times,call method at delegate then go into delegate,and over and over,it's messy.BabyBluetooth favor to using block.
@@ -150,7 +150,7 @@ peripheral model demo see :[BluetoothStubOnIOS](https://github.com/coolnameismy/
 
 # how to install
 
-##1 manual
+## 1 manual
 step1: let src folder‘s files import your project
 
 step2:import .h
@@ -159,7 +159,7 @@ step2:import .h
 #import "BabyBluetooth.h"
 ````
 
-##2 cocoapods
+## 2 cocoapods
 step1:add the following line to your Podfile:
 ````
 pod 'BabyBluetooth','~> 0.6.0'


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
